### PR TITLE
 Change makefile to only include needed files from embedded-common

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+ * [`changed`] Makefile to only include needed files from embedded-common
+
 ## [0.1.2] - 2020-08-24
 
  * `[fixed]` Fix overflow bug with high flow rates (#20)

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,12 @@ $(release_drivers): sfm-common/sfm_git_version.c
 	export pkgname="$${driver}-$${tag}" && \
 	export pkgdir="release/$${pkgname}" && \
 	rm -rf "$${pkgdir}" && mkdir -p "$${pkgdir}" && \
-	cp -r embedded-common/* "$${pkgdir}" && \
+	cp -r embedded-common/hw_i2c/ "$${pkgdir}" && \
+	cp -r embedded-common/sw_i2c/ "$${pkgdir}" && \
+	cp embedded-common/sensirion_arch_config.h "$${pkgdir}" && \
+	cp embedded-common/sensirion_common.c "$${pkgdir}" && \
+	cp embedded-common/sensirion_common.h "$${pkgdir}" && \
+	cp embedded-common/sensirion_i2c.h "$${pkgdir}" && \
 	cp -r sfm-common/* "$${pkgdir}" && \
 	cp -r $${driver}/* "$${pkgdir}" && \
 	cp CHANGELOG.md LICENSE "$${pkgdir}" && \


### PR DESCRIPTION
Change makefile to only include the needed parts of embedded-common
in the release package.

Check the following:

 - [ ] Breaking changes marked in commit message
 - [x] Changelog updated
 - [na] Code style cleaned (ran `make style-fix`)
 - [na] Tested on actual hardware
